### PR TITLE
Handle Negative Pool Sizes

### DIFF
--- a/engine/wasm.go
+++ b/engine/wasm.go
@@ -101,9 +101,9 @@ func (s *Server) LoadModule(cfg ModuleConfig) error {
 	m.ctx, m.cancel = context.WithCancel(context.Background())
 
 	// Set Pool Size
-	m.poolSize = uint64(cfg.PoolSize)
-	if cfg.PoolSize == 0 {
-		m.poolSize = uint64(DefaultPoolSize)
+	m.poolSize = uint64(DefaultPoolSize)
+	if cfg.PoolSize > 0 {
+		m.poolSize = uint64(cfg.PoolSize)
 	}
 
 	// Read the WASM module file

--- a/engine/wasm_test.go
+++ b/engine/wasm_test.go
@@ -61,6 +61,17 @@ func TestWASMModuleCreation(t *testing.T) {
 		},
 	})
 
+	// Negative Pool Size
+	mc = append(mc, ModuleCase{
+		Name: "Negative Pool Size",
+		Pass: true,
+		ModuleConf: ModuleConfig{
+			Name:     "A Module",
+			PoolSize: -1,
+			Filepath: "../testdata/hello-go/hello.wasm",
+		},
+	})
+
 	// No File
 	mc = append(mc, ModuleCase{
 		Name: "No File",


### PR DESCRIPTION
Today if someone were to specify a negative pool size, it would cause a panic. This change handles it by assuming any value less than one is going to be the default size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the logic for the server's module pool size setting to ensure it defaults correctly when not specified.
  
- **Tests**
	- Implemented a new test case to verify behavior with negative pool size values during module creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->